### PR TITLE
Remove media_files completely and add alt text for normal tweets

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -5,7 +5,7 @@ It includes the following settings:
 ============================
 
     MAN CONFIGURATION
-- GrabArticles: Whether to grab articles on twitter. (Note if you have GrabMediate Disabled, this will still download media for articles)
+- GrabArticles: Whether to grab articles on twitter. (Note if you have GrabMedia Disabled, this will still download media for articles)
 - ConvertLinks: Whether to convert links in tweets from the twitter url shortner to its main link.
 - GrabMedia: Whether to grab media from tweets.(images, videos, gifs) Not the related to articles.
 - GrabTweetQuoted: Whether to grab the tweet it quoted.

--- a/functions.py
+++ b/functions.py
@@ -197,7 +197,7 @@ async def modify_tweet(tweet, subtweet=False, parent_id=None, path_name=None, pa
         data_tweet["tweet_parsed"] = tweet.text
 
     if cfg["GrabMedia"] == True:
-        data_tweet["media_files"] = []
+        data_tweet["media"] = []
     # Checks if media is in tweet data and fetches it
         if len(tweet.media) > 0:
             print(f"\n{Fore.MAGENTA}Found and Downloading All Media...{Fore.WHITE}")
@@ -205,7 +205,7 @@ async def modify_tweet(tweet, subtweet=False, parent_id=None, path_name=None, pa
                 file_name = await media.download(None, modify_download)
                 shutil.copyfile(base_path + file_name, path_name + "media" + os.sep + current_id + os.sep + file_name)
                 os.remove(base_path + file_name)
-                data_tweet["media_files"].append({
+                data_tweet["media"].append({
                 "url": media.url,
                 "alt_text": media.alt_text,
                 "file_name": file_name

--- a/functions.py
+++ b/functions.py
@@ -209,6 +209,12 @@ async def modify_tweet(tweet, subtweet=False, parent_id=None, path_name=None, pa
                 "url": media.url,
                 "alt_text": media.alt_text,
                 "file_name": file_name
+                "source_user": []
+                })
+                data_tweet["media"][-1]["source_user"].append({
+                "username": media.source_user.username,
+                "display": media.source_user.name,
+                "verified": media.source_user.verified
                 })
             
     # Checks if tweet is Quoting another tweet and tries to download the tweet it quoted

--- a/functions.py
+++ b/functions.py
@@ -132,31 +132,31 @@ async def modify_tweet(tweet, subtweet=False, parent_id=None, path_name=None, pa
             if len(tweet.article.media) > 0:
                 print(f"{Fore.MAGENTA}Found Article Media...{Fore.WHITE}")
                 data_tweet["article"]["media"] = []
-                data_tweet["article"]["media_files"] = []
                 for media in tweet.article.media:
                     data_url = None
+                    if "url" in media.__dict__:
+                        data_url = media.url
+                    else:
+                        best_stream = await media.best_stream()
+                        data_url = best_stream.url
+                    file_name = await download_media(data_url, modify_download)
+                    shutil.copyfile(base_path + file_name, path_name + "media" + os.sep + current_id + os.sep + file_name)
+                    os.remove(base_path + file_name)
                     if "url" in media.__dict__:
                         data_tweet["article"]["media"].append({
                             "url": media.url,
                             "alt_text": media.alt_text,
                             "width": media.width,
-                            "height": media.height
+                            "height": media.height,
+                            "file_name": file_name
                         })
-                        data_url = media.url
                     else:
-                        best_stream = await media.best_stream()
-                        data_url = best_stream.url
                         data_tweet["article"]["media"].append({
                             "url": best_stream.url,
                             "content_type": best_stream.content_type.lower(),
-                            "alt_text": media.alt_text
+                            "alt_text": media.alt_text,
+                            "file_name": file_name
                         })
-                    file_name = await download_media(data_url, modify_download)
-                    shutil.copyfile(base_path + file_name, path_name + "media" + os.sep + current_id + os.sep + file_name)
-                    os.remove(base_path + file_name)
-                    data_tweet["article"]["media_files"].append(file_name)
-
-
 
     if cfg["ConvertLinks"] == True:
         data_tweet["href_links"] = []
@@ -203,9 +203,13 @@ async def modify_tweet(tweet, subtweet=False, parent_id=None, path_name=None, pa
             print(f"\n{Fore.MAGENTA}Found and Downloading All Media...{Fore.WHITE}")
             for media in tweet.media:
                 file_name = await media.download(None, modify_download)
-                data_tweet["media_files"].append(file_name)
                 shutil.copyfile(base_path + file_name, path_name + "media" + os.sep + current_id + os.sep + file_name)
                 os.remove(base_path + file_name)
+                data_tweet["media_files"].append({
+                "url": media.url,
+                "alt_text": media.alt_text,
+                "file_name": file_name
+                })
             
     # Checks if tweet is Quoting another tweet and tries to download the tweet it quoted
     if cfg["GrabTweetQuoted"] == True:


### PR DESCRIPTION
I feel like normal tweet media downloads needs a rework like articles media downloads, but for now this'll do.

- Remove "media_files" completely (it got combined into "media" like cover images, and helps with alt text)
- Add Alt Text for normal tweets (progresses #7)
- GrabMediate
- Add source_user (not sure if articles support this) (progresses #7)